### PR TITLE
Fixing Windows tests on AppVeyor

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -3,7 +3,7 @@
 # If error is caught, delete the destfile
 dl_try <- function(url, destfile) {
   tryCatch({
-    download.file(url, destfile)
+    download.file(url, destfile, mode="wb")
   },
   error = function(e) {
     message(paste("Could not download file from url", url))


### PR DESCRIPTION
This should fix the AppVeyor errors (see [link](https://ci.appveyor.com/project/neuroconductor-releases/radtools/build/job/k3t7gxrnuhd30ryc)). Passing version, after patch can be found here [here](https://ci.appveyor.com/project/adigherman/radtools/build/job/faljj5t0xldxmbi5). Please resubmit to [Neuroconductor](https://neuroconductor.org/submit-package) once this is incorporated. Thanks!